### PR TITLE
fix: empty string causes panic

### DIFF
--- a/stringwrap.go
+++ b/stringwrap.go
@@ -89,7 +89,11 @@ type WrappedStringSeq struct {
 
 // lastWrappedLine pulls the last wrapped line that has been parsed
 func (s *WrappedStringSeq) lastWrappedLine() *WrappedString {
-	return &s.WrappedLines[len(s.WrappedLines)-1]
+	n := len(s.WrappedLines)
+	if n == 0 {
+		return nil
+	}
+	return &s.WrappedLines[n-1]
 }
 
 // appendWrappedSeq adds a new WrappedString to the existing slice
@@ -489,7 +493,7 @@ func stringWrap(
 	// remove the last new line from the wrapped buffer
 	// if the last line is not a hard break.
 	lastWrappedLine := wrappedStringSeq.lastWrappedLine()
-	if !lastWrappedLine.IsHardBreak {
+	if lastWrappedLine != nil && !lastWrappedLine.IsHardBreak {
 		stateMachine.buffer.Truncate(stateMachine.buffer.Len() - 1)
 		lastWrappedLine.LastSegmentInOrig = true
 	}

--- a/stringwrap_test.go
+++ b/stringwrap_test.go
@@ -141,8 +141,12 @@ func TestStringWrap(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("Wrapped String Test %d", idx+1), func(t *testing.T) {
 			wrapped, seq, err := wrapString(tt)
+			expectedLines := 0
+			if wrapped != "" {
+				expectedLines = len(strings.Split(wrapped, "\n"))
+			}
 			assert.Nil(t, err)
-			assert.Equal(t, len(seq.WrappedLines), len(strings.Split(wrapped, "\n")))
+			assert.Equal(t, expectedLines, len(seq.WrappedLines))
 			assert.Equal(t, tt.wrapped, wrapped)
 		})
 	}

--- a/stringwrap_test.go
+++ b/stringwrap_test.go
@@ -129,6 +129,13 @@ func TestStringWrap(t *testing.T) {
 			trimWhitespace: true,
 			splitWord:      true,
 		},
+		{
+			input:          "",
+			wrapped:        "",
+			limit:          5,
+			trimWhitespace: true,
+			splitWord:      true,
+		},
 	}
 
 	for idx, tt := range tests {


### PR DESCRIPTION
At the moment, if I pass an empty string as per the added test case, then the `stringwrap` function panics:

```console
$ go test ./...
--- FAIL: TestStringWrap (0.00s)
    --- FAIL: TestStringWrap/Wrapped_String_Test_15 (0.00s)
panic: runtime error: index out of range [-1] [recovered, repanicked]

goroutine 37 [running]:
testing.tRunner.func1.2({0x10249e600, 0x140000b8690})
        /opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1872 +0x190
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1875 +0x31c
panic({0x10249e600?, 0x140000b8690?})
        /opt/homebrew/Cellar/go/1.25.4/libexec/src/runtime/panic.go:783 +0x120
github.com/galactixx/stringwrap.(*WrappedStringSeq).lastWrappedLine(...)
        /Users/rhu/dev/stringwrap/stringwrap.go:92
github.com/galactixx/stringwrap.stringWrap({0x102445868, 0x0}, 0x5, 0x4, 0x1, 0x1)
        /Users/rhu/dev/stringwrap/stringwrap.go:491 +0x548
github.com/galactixx/stringwrap.StringWrapSplit(...)
        /Users/rhu/dev/stringwrap/stringwrap.go:542
github.com/galactixx/stringwrap.wrapString({{0x102445868, 0x0}, {0x102445868, 0x0}, 0x5, 0x1, 0x1})
        /Users/rhu/dev/stringwrap/stringwrap_test.go:25 +0x48
github.com/galactixx/stringwrap.TestStringWrap.func1(0x14000139180)
        /Users/rhu/dev/stringwrap/stringwrap_test.go:143 +0x40
testing.tRunner(0x14000139180, 0x1400008eef0)
        /opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 22
        /opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1997 +0x364
FAIL    github.com/galactixx/stringwrap 0.466s
FAIL
```

This PR adds a test case to `TestStringWrap` to reproduce the panic.

edit: ~~LMK if you'd like me to provide a fix & i'll add further commits to this PR~~ I've pushed a second commit fixing the issue.